### PR TITLE
Add f2fs support

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -25,6 +25,9 @@
 
 TARGET_NO_BOOTLOADER := true
 
+# F2FS filesystem
+TARGET_USERIMAGES_USE_F2FS := true
+
 TARGET_BOOTLOADER_BOARD_NAME := piranha
 
 # Binder API version

--- a/rootdir/fstab.espresso
+++ b/rootdir/fstab.espresso
@@ -4,12 +4,14 @@
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
 
-/dev/block/platform/omap_hsmmc.1/by-name/FACTORYFS /system             ext4      ro                                                    wait
-/dev/block/platform/omap_hsmmc.1/by-name/EFS       /efs                ext4      nosuid,nodev                                          wait,check
-/dev/block/platform/omap_hsmmc.1/by-name/CACHE     /cache              ext4      noatime,nosuid,nodev,nomblk_io_submit,errors=panic    wait,check
-/dev/block/platform/omap_hsmmc.1/by-name/DATAFS    /data               ext4      noatime,nosuid,nodev,nomblk_io_submit,errors=panic    wait,check,encryptable=footer
-/dev/block/platform/omap_hsmmc.1/by-name/KERNEL    /boot               emmc      defaults                                              defaults
-/dev/block/platform/omap_hsmmc.1/by-name/RECOVERY  /recovery           emmc      defaults                                              defaults
+/dev/block/platform/omap_hsmmc.1/by-name/FACTORYFS   /system             ext4      ro                                                                               wait
+/dev/block/platform/omap_hsmmc.1/by-name/EFS         /efs                ext4      nosuid,nodev                                                                     wait,check
+/dev/block/platform/omap_hsmmc.1/by-name/CACHE       /cache              ext4      noatime,nosuid,nodev,nomblk_io_submit,errors=panic                               wait,check
+/dev/block/platform/omap/omap_hsmmc.1/by-name/CACHE  /cache              f2fs      noatime,nodiratime,nosuid,nodev,background_gc=off,inline_xattr,active_logs=2     wait
+/dev/block/platform/omap_hsmmc.1/by-name/DATAFS      /data               ext4      noatime,nosuid,nodev,nomblk_io_submit,errors=panic                               wait,check,encryptable=footer
+/dev/block/platform/omap/omap_hsmmc.1/by-name/DATAFS /data               f2fs      noatime,nosuid,nodev,background_gc=off,inline_xattr,active_logs=2                wait,encryptable=footer
+/dev/block/platform/omap_hsmmc.1/by-name/KERNEL      /boot               emmc      defaults                                                                         defaults
+/dev/block/platform/omap_hsmmc.1/by-name/RECOVERY    /recovery           emmc      defaults                                                                         defaults
 
 # vold-managed volumes
 /devices/platform/omap_hsmmc.0/mmc_host/mmc1*      auto                auto      defaults                                              wait,voldmanaged=sdcard1:auto,encryptable=userdata


### PR DESCRIPTION
Implement f2fs support for both espressowifi and espresso3g. 

Changes to BoardConfigCommon apply to both devices
```
[buildserver@archlinux-pc samsung]$ grep -Rne "BoardConfigCommon.mk" espresso3g
espresso3g/BoardConfig.mk:18:include device/samsung/espresso/BoardConfigCommon.mk
```

Build works and installs successfully
```
[100% 1823/1823] Package UA-OTA: /mnt/Files/jenkins/Android/UnlegacyAndroid/out/target/product/espresso/ua_espresso-8.1.0-20220213.zip

#### build completed successfully (13:49 (mm:ss)) ####
```